### PR TITLE
Add EventsDropped telemetry and eventsRun connection for nasa/fprime#5349

### DIFF
--- a/FlightExamples/ExamplesDeployment/Top/ExamplesDeploymentPackets.fppi
+++ b/FlightExamples/ExamplesDeployment/Top/ExamplesDeploymentPackets.fppi
@@ -29,6 +29,7 @@ telemetry packets Packets {
 
   packet CDHErrors id 2 group 1 {
     CdhCore.$health.PingLateWarnings
+    CdhCore.events.EventsDropped
 
     FileHandling.fileUplink.Warnings
     FileHandling.fileDownlink.Warnings

--- a/FlightExamples/ExamplesDeployment/Top/topology.fpp
+++ b/FlightExamples/ExamplesDeployment/Top/topology.fpp
@@ -157,6 +157,7 @@ module ExamplesDeployment {
       rateGroupDriver.CycleOut[Ports_RateGroups.rateGroup3] -> rateGroup3.CycleIn
       rateGroup3.RateGroupMemberOut[0] -> CdhCore.$health.Run
       rateGroup3.RateGroupMemberOut[1] -> commsBufferManager.schedIn
+      rateGroup3.RateGroupMemberOut[2] -> CdhCore.Subtopology.eventsRun
     }
 
     connections CdhCore_cmdSeq {


### PR DESCRIPTION
Companion to nasa/fprime#5349 (Report number of events dropped by EventManager).

Changes:
- Add `CdhCore.events.EventsDropped` to `CDHErrors` telemetry packet
- Wire `rateGroup3.RateGroupMemberOut[2] -> CdhCore.Subtopology.eventsRun` to drive the dropped-event telemetry at the rate group cadence